### PR TITLE
Bump AGP to match Android Studio 3.4 Canary 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Some tech you can find inside:
  
 ## Development setup
 
-You require the latest Android Studio 3.1 (or newer) to be able to build the app.
+You require the latest Android Studio 3.4 (or newer) to be able to build the app.
 
 ## Contributions
 

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ buildscript {
     }
     dependencies {
         //noinspection GradleDependency
-        classpath 'com.android.tools.build:gradle:3.4.0-alpha05'
+        classpath 'com.android.tools.build:gradle:3.4.0-alpha06'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath 'com.google.gms:google-services:4.0.1'
         classpath "com.google.gms:oss-licenses:0.9.2"


### PR DESCRIPTION
Also update README to indicate Android Studio 3.4 and higher is required
for development.