### PR TITLE
Update Gradle plugin to 3.4.0-alpha08

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ buildscript {
     }
     dependencies {
         //noinspection GradleDependency
-        classpath 'com.android.tools.build:gradle:3.4.0-alpha06'
+        classpath 'com.android.tools.build:gradle:3.4.0-alpha08'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath 'com.google.gms:google-services:4.0.1'
         classpath "com.google.gms:oss-licenses:0.9.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Nov 16 09:28:40 GMT 2018
+#Fri Dec 14 14:46:17 PST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1-milestone-1-all.zip


### PR DESCRIPTION
This reflects the latest Android Studio Canary.

This also requires updating Gradle to 5.1 milestone 1.

Test: Verified that app compiles and runs.